### PR TITLE
Fix delete feature for pets and visits

### DIFF
--- a/src/app/pets/pet.service.ts
+++ b/src/app/pets/pet.service.ts
@@ -66,7 +66,9 @@ export class PetService {
   }
 
   deletePet(pet_id: string): Observable<number> {
-    return this._http.delete(this.entity_url + '/' + pet_id)
+    const headers = new Headers({'Content-Type': ' application/json;charset=UTF-8'});
+    const options = new RequestOptions({headers: headers});
+    return this._http.delete(this.entity_url + '/' + pet_id, options)
       .map((response: Response) => response.status)
       .catch(this.handleError);
   }

--- a/src/app/visits/visit.service.ts
+++ b/src/app/visits/visit.service.ts
@@ -65,7 +65,9 @@ export class VisitService {
   }
 
   deleteVisit(visit_id: string): Observable<number> {
-    return this._http.delete((this.entity_url + '/' + visit_id))
+    const headers = new Headers({'Content-Type': ' application/json;charset=UTF-8'});
+    const options = new RequestOptions({headers: headers});
+    return this._http.delete((this.entity_url + '/' + visit_id), options)
       .map((response: Response) => response.status)
       .catch(this.handleError);
 


### PR DESCRIPTION
I don't know why, but to call the back-end DELETE REST API, we have to pre-send an OPTION with a content-type set (like for PUT and POST HTTP requests). 